### PR TITLE
[17.0][FIX] stock_request: avoid failure on handling errors

### DIFF
--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -404,7 +404,7 @@ class StockRequest(models.Model):
                 )
                 self.env["procurement.group"].run(procurements)
             except UserError as error:
-                errors.append(error.name)
+                errors.append(str(error))
         if errors:
             raise UserError("\n".join(errors))
         return True


### PR DESCRIPTION
Fixes the following:

```
File "/home/odoo/src/user/test/stock_request/models/stock_request.py", line 407, in _action_launch_procurement_rule
errors.append(error.name)
AttributeError: 'UserError' object has no attribute 'name'

```

