### PR TITLE
[16.0][FWP][IMP] stock_request: Change rounding method to HALF-UP in qty_in_proress computation

### DIFF
--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -162,9 +162,15 @@ class StockRequest(models.Model):
             done_qty = abs(other_qty - incoming_qty)
             open_qty = sum(request.allocation_ids.mapped("open_product_qty"))
             uom = request.product_id.uom_id
-            request.qty_done = uom._compute_quantity(done_qty, request.product_uom_id)
+            request.qty_done = uom._compute_quantity(
+                done_qty,
+                request.product_uom_id,
+                rounding_method="HALF-UP",
+            )
             request.qty_in_progress = uom._compute_quantity(
-                open_qty, request.product_uom_id
+                open_qty,
+                request.product_uom_id,
+                rounding_method="HALF-UP",
             )
             request.qty_cancelled = (
                 max(
@@ -172,6 +178,7 @@ class StockRequest(models.Model):
                     uom._compute_quantity(
                         request.product_qty - done_qty - open_qty,
                         request.product_uom_id,
+                        rounding_method="HALF-UP",
                     ),
                 )
                 if request.allocation_ids

--- a/stock_request/models/stock_request_abstract.py
+++ b/stock_request/models/stock_request_abstract.py
@@ -32,7 +32,9 @@ class StockRequest(models.AbstractModel):
     def _compute_product_qty(self):
         for rec in self:
             rec.product_qty = rec.product_uom_id._compute_quantity(
-                rec.product_uom_qty, rec.product_id.product_tmpl_id.uom_id
+                rec.product_uom_qty,
+                rec.product_id.product_tmpl_id.uom_id,
+                rounding_method="HALF-UP",
             )
 
     name = fields.Char(copy=False, required=True, readonly=True, default="/")

--- a/stock_request/models/stock_request_allocation.py
+++ b/stock_request/models/stock_request_allocation.py
@@ -69,7 +69,9 @@ class StockRequestAllocation(models.Model):
     def _compute_requested_product_qty(self):
         for rec in self:
             rec.requested_product_qty = rec.product_uom_id._compute_quantity(
-                rec.requested_product_uom_qty, rec.product_id.uom_id
+                rec.requested_product_uom_qty,
+                rec.product_id.uom_id,
+                rounding_method="HALF-UP",
             )
 
     @api.depends(

--- a/stock_request/tests/test_stock_request.py
+++ b/stock_request/tests/test_stock_request.py
@@ -1319,3 +1319,45 @@ class TestStockRequestOrderState(TestStockRequest):
         self.assertEqual(self.request_a.state, "cancel")
         self.assertEqual(self.request_b.state, "done")
         self.assertEqual(self.order.state, "done")
+
+    def test_rounding_half_up_in_progress_01(self):
+        product_half_up = self._create_product(
+            "HALFUP", "HalfUp Product", self.main_company.id
+        )
+        product_half_up.uom_id.rounding = 1.0
+        vals = {
+            "product_id": product_half_up.id,
+            "product_uom_id": product_half_up.uom_id.id,
+            "product_uom_qty": 0.5,
+            "company_id": self.main_company.id,
+            "warehouse_id": self.warehouse.id,
+            "location_id": self.virtual_loc.id,
+        }
+        stock_request = self.stock_request.create(vals)
+        stock_request.action_confirm()
+        self.assertEqual(
+            stock_request.qty_in_progress,
+            1,
+            "Quantity in progress should be the rounded up quantity after confirmation",
+        )
+
+    def test_rounding_half_up_in_progress_02(self):
+        product_half_up = self._create_product(
+            "HALFUP", "HalfUp Product", self.main_company.id
+        )
+        product_half_up.uom_id.rounding = 1.0
+        vals = {
+            "product_id": product_half_up.id,
+            "product_uom_id": product_half_up.uom_id.id,
+            "product_uom_qty": 1.49,
+            "company_id": self.main_company.id,
+            "warehouse_id": self.warehouse.id,
+            "location_id": self.virtual_loc.id,
+        }
+        stock_request = self.stock_request.create(vals)
+        stock_request.action_confirm()
+        self.assertEqual(
+            stock_request.qty_in_progress,
+            1,
+            "Quantity in progress should be the rounded down quantity after confirmation",
+        )


### PR DESCRIPTION
FWP of this commit: https://github.com/OCA/stock-logistics-warehouse/commit/de2a85eb55517002b4b517583e724bbfdc3b3941

in this PR: https://github.com/OCA/stock-logistics-warehouse/pull/1989