### PR TITLE
[16.0][IMP] stock_request: Improve _check_qty constrain (moved to stock.request)

### DIFF
--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -125,6 +125,18 @@ class StockRequest(models.Model):
         ("name_uniq", "unique(name, company_id)", "Stock Request name must be unique")
     ]
 
+    @api.constrains("state", "product_qty")
+    def _check_qty(self):
+        for rec in self:
+            if rec.state == "draft" and rec.product_qty <= 0:
+                raise ValidationError(
+                    _("Stock Request product quantity has to be strictly positive.")
+                )
+            elif rec.state != "draft" and rec.product_qty < 0:
+                raise ValidationError(
+                    _("Stock Request product quantity cannot be negative.")
+                )
+
     def _get_all_origin_moves(self, move):
         all_moves = move
         if move.move_orig_ids:

--- a/stock_request/models/stock_request_abstract.py
+++ b/stock_request/models/stock_request_abstract.py
@@ -206,14 +206,6 @@ class StockRequest(models.AbstractModel):
                 )
             )
 
-    @api.constrains("product_qty")
-    def _check_qty(self):
-        for rec in self:
-            if rec.product_qty <= 0:
-                raise ValidationError(
-                    _("Stock Request product quantity has to be strictly positive.")
-                )
-
     @api.onchange("warehouse_id")
     def onchange_warehouse_id(self):
         """Finds location id for changed warehouse."""

--- a/stock_request_purchase/models/stock_request.py
+++ b/stock_request_purchase/models/stock_request.py
@@ -42,10 +42,11 @@ class StockRequest(models.Model):
     def action_cancel(self):
         """Propagate the cancellation to the generated purchase orders."""
         res = super().action_cancel()
-        self.sudo().purchase_ids.filtered(
-            lambda x: x.state not in ("purchase", "done", "cancel")
-            and x.stock_request_ids == self
-        ).button_cancel()
+        if not self.env.context.get("skip_cancel_po_from_stock_request"):
+            self.sudo().purchase_ids.filtered(
+                lambda x: x.state not in ("purchase", "done", "cancel")
+                and x.stock_request_ids == self
+            ).button_cancel()
         return res
 
     def action_view_purchase(self):


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/stock-logistics-warehouse/pull/2163

Improve _check_qty constrain (moved to `stock.request`)

Example use case:
- A request (not draft) must be able to be changed to quantity 0 (although not negative).

Add context key to skip cancel purchase.

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT50450