### PR TITLE
[16.0][IMP] stock_request_purchase: Cancel stock request when unlinking related purchase order lines

### DIFF
--- a/stock_request_purchase/models/purchase_order_line.py
+++ b/stock_request_purchase/models/purchase_order_line.py
@@ -12,6 +12,21 @@ class PurchaseOrderLine(models.Model):
         comodel_name="stock.request", string="Stock Requests", copy=False
     )
 
+    def unlink(self):
+        """
+        Cancel the stock.request
+        related to the purchase order line
+        because it does not occur automatically
+        and causes inconsistency by keeping the SR state as 'In Progress' (open).
+        """
+        stock_request_to_cancel = self.env["stock.request"]
+        for purchase_line in self:
+            stock_request_to_cancel |= purchase_line.stock_request_ids
+        res = super().unlink()
+        if stock_request_to_cancel:
+            stock_request_to_cancel.action_cancel()
+        return res
+
     def _prepare_stock_moves(self, picking):
         res = super()._prepare_stock_moves(picking)
         for re in res:

--- a/stock_request_purchase/tests/test_stock_request_purchase.py
+++ b/stock_request_purchase/tests/test_stock_request_purchase.py
@@ -168,6 +168,83 @@ class TestStockRequestPurchase(TestStockRequest):
         stock_request.action_cancel()
         self.assertEqual(stock_request.purchase_ids.state, "cancel")
 
+    def test_unlink_purchase_order_line(self):
+        """
+        Test that when a purchase order line is unlinked,
+        the related stock requests are cancelled
+        """
+        expected_date = fields.Datetime.now()
+        product2 = self._create_product(
+            "P2",
+            "product2",
+            False,
+            route_ids=[(6, 0, self.route_buy.ids)],
+            seller_ids=[(0, 0, {"partner_id": self.supplier.id, "delay": 5})],
+        )
+        vals = {
+            "company_id": self.main_company.id,
+            "warehouse_id": self.warehouse.id,
+            "location_id": self.warehouse.lot_stock_id.id,
+            "expected_date": expected_date,
+            "stock_request_ids": [
+                (
+                    0,
+                    0,
+                    {
+                        "product_id": self.product.id,
+                        "product_uom_id": self.product.uom_id.id,
+                        "product_uom_qty": 10.0,
+                        "company_id": self.main_company.id,
+                        "warehouse_id": self.warehouse.id,
+                        "location_id": self.warehouse.lot_stock_id.id,
+                        "expected_date": expected_date,
+                    },
+                ),
+                (
+                    0,
+                    0,
+                    {
+                        "product_id": product2.id,
+                        "product_uom_id": product2.uom_id.id,
+                        "product_uom_qty": 20.0,
+                        "company_id": self.main_company.id,
+                        "warehouse_id": self.warehouse.id,
+                        "location_id": self.warehouse.lot_stock_id.id,
+                        "expected_date": expected_date,
+                    },
+                ),
+            ],
+        }
+
+        order = (
+            self.env["stock.request.order"]
+            .with_user(self.stock_request_user)
+            .create(vals)
+        )
+
+        order.action_confirm()
+        self.assertEqual(order.state, "open")
+        self.assertEqual(len(order.purchase_ids), 1)
+        purchase = order.purchase_ids[0]
+        purchase_line1 = purchase.order_line.filtered(
+            lambda x: x.product_id == self.product
+        )
+        purchase_line2 = purchase.order_line.filtered(
+            lambda x: x.product_id == product2
+        )
+        stock_request1 = order.stock_request_ids.filtered(
+            lambda x: x.product_id == self.product
+        )
+        stock_request2 = order.stock_request_ids.filtered(
+            lambda x: x.product_id == product2
+        )
+        purchase_line1.sudo().unlink()
+        self.assertEqual(stock_request1.state, "cancel")
+        self.assertEqual(order.state, "open")
+        purchase_line2.sudo().unlink()
+        self.assertEqual(stock_request2.state, "cancel")
+        self.assertEqual(order.state, "cancel")
+
     def test_view_actions(self):
         expected_date = fields.Datetime.now()
         vals = {


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/stock-logistics-warehouse/pull/2152

Before this commit, when a purchase order line was unlinked, the stock request remained open. After this commit, related stock requests are canceled.

@Tecnativa TT50615

ping @pedrobaeza @victoralmau