### PR TITLE
[17.0][IMP] stock_request: Add config to enable/disable requested_by check

### DIFF
--- a/stock_request/README.rst
+++ b/stock_request/README.rst
@@ -122,6 +122,9 @@ Contributors
 -  Kitti U. <kittiu@ecosoft.co.th>
 -  Bernat Puig <bernat.puig@forgeflow.com>
 -  Oriol Miranda <oriol.miranda@forgeflow.com>
+-  `APSL-Nagarro <https://apsl.tech>`__:
+
+   -  Bernat Obrador <bobrador@apsl.net>
 
 Maintainers
 -----------

--- a/stock_request/models/res_company.py
+++ b/stock_request/models/res_company.py
@@ -15,3 +15,7 @@ class ResCompany(models.Model):
     stock_request_check_available_first = fields.Boolean(
         string="Check available stock first"
     )
+    stock_request_check_order_requested_by = fields.Boolean(
+        string="Only allow edit stock request orders if requested by the same user",
+        default=True,
+    )

--- a/stock_request/models/res_config_settings.py
+++ b/stock_request/models/res_config_settings.py
@@ -35,6 +35,10 @@ class ResConfigSettings(models.TransientModel):
     )
 
     module_stock_request_mrp = fields.Boolean(string="Stock Request for Manufacturing")
+    check_order_requested_by = fields.Boolean(
+        related="company_id.stock_request_check_order_requested_by",
+        readonly=False,
+    )
 
     # Dependencies
     @api.onchange("stock_request_allow_virtual_loc")

--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -196,6 +196,11 @@ class StockRequest(models.Model):
 
     @api.constrains("order_id", "requested_by")
     def check_order_requested_by(self):
+        check_order_requested_by = (
+            self.env.company.stock_request_check_order_requested_by
+        )
+        if not check_order_requested_by:
+            return
         for stock_request in self:
             if (
                 stock_request.order_id

--- a/stock_request/readme/CONTRIBUTORS.md
+++ b/stock_request/readme/CONTRIBUTORS.md
@@ -11,3 +11,5 @@
 - Kitti U. \<<kittiu@ecosoft.co.th>\>
 - Bernat Puig \<<bernat.puig@forgeflow.com>\>
 - Oriol Miranda \<<oriol.miranda@forgeflow.com>\>
+- [APSL-Nagarro](<https://apsl.tech>):
+  - Bernat Obrador \<<bobrador@apsl.net>\>

--- a/stock_request/static/description/index.html
+++ b/stock_request/static/description/index.html
@@ -464,6 +464,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Kitti U. &lt;<a class="reference external" href="mailto:kittiu&#64;ecosoft.co.th">kittiu&#64;ecosoft.co.th</a>&gt;</li>
 <li>Bernat Puig &lt;<a class="reference external" href="mailto:bernat.puig&#64;forgeflow.com">bernat.puig&#64;forgeflow.com</a>&gt;</li>
 <li>Oriol Miranda &lt;<a class="reference external" href="mailto:oriol.miranda&#64;forgeflow.com">oriol.miranda&#64;forgeflow.com</a>&gt;</li>
+<li><a class="reference external" href="https://apsl.tech">APSL-Nagarro</a>:<ul>
+<li>Bernat Obrador &lt;<a class="reference external" href="mailto:bobrador&#64;apsl.net">bobrador&#64;apsl.net</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/stock_request/views/res_config_settings_views.xml
+++ b/stock_request/views/res_config_settings_views.xml
@@ -62,6 +62,17 @@
                                 >By default, available stock is not used</div>
                             </div>
                         </setting>
+                        <setting>
+                            <field
+                                name="check_order_requested_by"
+                                string="Check Stock Request Order requested by"
+                            />
+                            <div class="content-group">
+                                <div
+                                    class="text-muted"
+                                >Only the user who submitted the request will be able to edit the stock request order.</div>
+                            </div>
+                        </setting>
                     </block>
                     <h2>Purchases</h2>
                     <block id="stock_request_purchase">


### PR DESCRIPTION
This PR introduces a new configuration setting that allows enabling or disabling the check for the requested_by field, which previously restricted users from editing stock request orders created by others. This enhancement provides greater flexibility for workflows where such validation is not required.

Added a new configuration parameter "Check Stock Request Order requested by" on stock request settings.

To test this changes:
1. Enable or disable the "Check Stock Request Order requested by" setting.
2. Create a Stock Request Order.
3. Try editing the stock request lines:
- If enabled, users will not be allowed to modify stock request lines unless they are the requestor.

- If disabled, users will be able to modify stock request lines regardless of who created the order.

cc https://github.com/APSL 9144

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review
