### PR TITLE
[16.0][IMP] stock_request_tier_validation: Change the use of the validated field to validation_status

### DIFF
--- a/stock_request_tier_validation/views/stock_request_order_view.xml
+++ b/stock_request_tier_validation/views/stock_request_order_view.xml
@@ -17,7 +17,7 @@
                 <filter
                     name="tier_validated"
                     string="Validated"
-                    domain="[('validated', '=', True)]"
+                    domain="[('validation_status', '=', 'validated')]"
                     help="Stock Requests validated and ready to be confirmed"
                 />
             </xpath>

--- a/stock_request_tier_validation/views/stock_request_view.xml
+++ b/stock_request_tier_validation/views/stock_request_view.xml
@@ -18,7 +18,7 @@
                     <filter
                         name="tier_validated"
                         string="Validated"
-                        domain="[('validated', '=', True)]"
+                        domain="[('validation_status', '=', 'validated')]"
                         help="Stock Requests validated and ready to be confirmed"
                     />
                 </group>


### PR DESCRIPTION
Change the use of the `validated` field to `validation_status`

Related to https://github.com/OCA/server-ux/pull/1084

Please @pedrobaeza can you review it?

@Tecnativa