### PR TITLE
[16.0][IMP] stock_request_tier_validation: add usererror and auto validation when confirm

### DIFF
--- a/stock_request_tier_validation/i18n/es.po
+++ b/stock_request_tier_validation/i18n/es.po
@@ -136,6 +136,13 @@ msgstr "Estado de la Validación"
 msgid "Validations"
 msgstr "Validaciones"
 
+#. module: stock_request_tier_validation
+#. odoo-python
+#: code:addons/stock_request_tier_validation/models/stock_request_order.py:0
+#, python-format
+msgid "You cannot confirm a stock request order that has been rejected."
+msgstr "No puedes confirmar un pedido de existencias que ha sido rechazado."
+
 #~ msgid "Rejected"
 #~ msgstr "Rechazado"
 

--- a/stock_request_tier_validation/i18n/it.po
+++ b/stock_request_tier_validation/i18n/it.po
@@ -119,6 +119,13 @@ msgid "Validated"
 msgstr "Approvata"
 
 #. module: stock_request_tier_validation
+#. odoo-python
+#: code:addons/stock_request_tier_validation/models/stock_request_order.py:0
+#, python-format
+msgid "You cannot confirm a stock request order that has been rejected."
+msgstr "Non puoi confermare una richiesta di magazzino che è stata rifiutata."
+
+#. module: stock_request_tier_validation
 #: model:ir.model.fields,field_description:stock_request_tier_validation.field_stock_request__validated_message
 #: model:ir.model.fields,field_description:stock_request_tier_validation.field_stock_request_order__validated_message
 msgid "Validated Message"

--- a/stock_request_tier_validation/i18n/stock_request_tier_validation.pot
+++ b/stock_request_tier_validation/i18n/stock_request_tier_validation.pot
@@ -132,3 +132,10 @@ msgstr ""
 #: model:ir.model.fields,field_description:stock_request_tier_validation.field_stock_request_order__review_ids
 msgid "Validations"
 msgstr ""
+
+#. module: stock_request_tier_validation
+#. odoo-python
+#: code:addons/stock_request_tier_validation/models/stock_request_order.py:0
+#, python-format
+msgid "You cannot confirm a stock request order that has been rejected."
+msgstr ""

--- a/stock_request_tier_validation/models/stock_request_order.py
+++ b/stock_request_tier_validation/models/stock_request_order.py
@@ -1,6 +1,7 @@
 # Copyright 2019-2020 ForgeFlow S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import api, models
+from odoo import _, api, models
+from odoo.exceptions import UserError
 
 
 class StockRequestOrder(models.Model):
@@ -16,3 +17,15 @@ class StockRequestOrder(models.Model):
         res = super()._get_under_validation_exceptions()
         res.append("route_id")
         return res
+
+    def action_confirm(self):
+        for order in self:
+            if order.validation_status == "rejected":
+                raise UserError(
+                    _(
+                        "You cannot confirm a stock request order that has been rejected."
+                    )
+                )
+            if order.validation_status == "pending":
+                order.validate_tier()
+        return super().action_confirm()


### PR DESCRIPTION
Automatically validate stock request orders on confirmation if they are pending, and block confirmation only when rejected.