### PR TITLE
[18.0][IMP] stock_request: improve route_id consitency avoiding non-sense resets

### DIFF
--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -350,6 +350,31 @@ class StockRequest(models.Model):
             "reference": self.name,
         }
 
+    @api.onchange("product_id")
+    def onchange_product_id(self):
+        if self.product_id:
+            self.product_uom_id = self.product_id.uom_id
+            order_route = self.order_id.route_id or self.env["stock.route"].browse(
+                self.env.context.get("default_route_id")
+            )
+            if order_route:
+                is_compatible = True
+                if order_route.product_selectable:
+                    product_routes = (
+                        self.product_id.route_ids
+                        | self.product_id.categ_id.total_route_ids
+                    )
+                    if order_route not in product_routes:
+                        is_compatible = False
+                if is_compatible:
+                    self.route_id = order_route.id
+
+    @api.onchange("route_id")
+    def onchange_route_id(self):
+        if self.order_id and self.order_id.route_id:
+            if self.route_id != self.order_id.route_id:
+                self.order_id.route_id = False
+
     def _prepare_stock_request_allocation(self, move):
         return {
             "stock_request_id": self.id,
@@ -461,6 +486,23 @@ class StockRequest(models.Model):
             if "order_id" in upd_vals:
                 order_id = self.env["stock.request.order"].browse(upd_vals["order_id"])
                 upd_vals["expected_date"] = order_id.expected_date
+                if (
+                    not upd_vals.get("route_id")
+                    and order_id.route_id
+                    and upd_vals.get("product_id")
+                ):
+                    product = self.env["product.product"].browse(upd_vals["product_id"])
+                    order_route = order_id.route_id
+                    is_compatible = True
+                    if order_route.product_selectable:
+                        product_routes = (
+                            product.route_ids | product.categ_id.total_route_ids
+                        )
+                        if order_route not in product_routes:
+                            is_compatible = False
+
+                    if is_compatible:
+                        upd_vals["route_id"] = order_route.id
             else:
                 upd_vals["expected_date"] = self._get_expected_date()
             vals_list_upd.append(upd_vals)

--- a/stock_request/models/stock_request_order.py
+++ b/stock_request/models/stock_request_order.py
@@ -136,8 +136,7 @@ class StockRequestOrder(models.Model):
 
     route_id = fields.Many2one(
         "stock.route",
-        compute="_compute_route_id",
-        inverse="_inverse_route_id",
+        string="Route",
         readonly=True,
         store=True,
         help="The route related to a stock request order",
@@ -188,25 +187,10 @@ class StockRequestOrder(models.Model):
             result |= location
         return result
 
-    @api.depends("stock_request_ids")
-    def _compute_route_id(self):
-        for order in self:
-            if order.stock_request_ids:
-                first_route = order.stock_request_ids[0].route_id or False
-                if any(r.route_id != first_route for r in order.stock_request_ids):
-                    first_route = False
-                order.route_id = first_route
-
-    def _inverse_route_id(self):
-        for order in self:
-            if order.route_id:
-                order.stock_request_ids.write({"route_id": order.route_id.id})
-
     @api.onchange("route_id")
     def _onchange_route_id(self):
-        if self.route_id:
-            for request in self.stock_request_ids:
-                request.route_id = self.route_id
+        for request in self.stock_request_ids:
+            request.route_id = self.route_id
 
     @api.depends("stock_request_ids.state")
     def _compute_state(self):

--- a/stock_request/tests/test_stock_request.py
+++ b/stock_request/tests/test_stock_request.py
@@ -1345,135 +1345,6 @@ class TestStockRequestOrderState(TestStockRequest):
             "Quantity in progress should be the rounded down after confirmation",
         )
 
-    def test_route_id_propagation_on_creation(self):
-        order_vals = {
-            "company_id": self.main_company.id,
-            "warehouse_id": self.warehouse.id,
-            "location_id": self.warehouse.lot_stock_id.id,
-            "expected_date": fields.Datetime.now(),
-            "route_id": self.route.id,
-            "stock_request_ids": [
-                Command.create(
-                    {
-                        "product_id": self.product.id,
-                        "product_uom_id": self.product.uom_id.id,
-                        "product_uom_qty": 5.0,
-                    },
-                ),
-                Command.create(
-                    {
-                        "product_id": self.product.id,
-                        "product_uom_id": self.product.uom_id.id,
-                        "product_uom_qty": 10.0,
-                    },
-                ),
-            ],
-        }
-        order = self.request_order.create(order_vals)
-        self.assertEqual(len(order.stock_request_ids), 2)
-        order.write({"route_id": self.route_3})
-        for request in order.stock_request_ids:
-            self.assertEqual(
-                request.route_id.id,
-                order.route_id.id,
-                "The route_id from stock.request.order has not "
-                "been set in the associated stock.requests.",
-            )
-
-    def test_compute_route_id_consistency_1(self):
-        order_vals = {
-            "company_id": self.main_company.id,
-            "warehouse_id": self.warehouse.id,
-            "location_id": self.warehouse.lot_stock_id.id,
-            "expected_date": fields.Datetime.now(),
-            "stock_request_ids": [
-                Command.create(
-                    {
-                        "product_id": self.product.id,
-                        "product_uom_id": self.product.uom_id.id,
-                        "product_uom_qty": 5.0,
-                        "route_id": self.route.id,
-                    },
-                ),
-                Command.create(
-                    {
-                        "product_id": self.product.id,
-                        "product_uom_id": self.product.uom_id.id,
-                        "product_uom_qty": 10.0,
-                        "route_id": self.route_3.id,
-                    },
-                ),
-            ],
-        }
-        order = self.request_order.create(order_vals)
-        order._compute_route_id()
-        self.assertFalse(
-            order.route_id,
-            "Route ID should be False due to inconsistent routes in stock requests.",
-        )
-
-    def test_compute_route_id_consistency_2(self):
-        order_vals = {
-            "company_id": self.main_company.id,
-            "warehouse_id": self.warehouse.id,
-            "location_id": self.warehouse.lot_stock_id.id,
-            "expected_date": fields.Datetime.now(),
-            "stock_request_ids": [
-                Command.create(
-                    {
-                        "product_id": self.product.id,
-                        "product_uom_id": self.product.uom_id.id,
-                        "product_uom_qty": 5.0,
-                        "route_id": self.route.id,
-                    },
-                ),
-                Command.create(
-                    {
-                        "product_id": self.product.id,
-                        "product_uom_id": self.product.uom_id.id,
-                        "product_uom_qty": 10.0,
-                        "route_id": self.route.id,
-                    },
-                ),
-            ],
-        }
-        order = self.request_order.create(order_vals)
-        order._compute_route_id()
-        self.assertEqual(order.route_id, self.route)
-
-    def test_inverse_route_id_propagation(self):
-        order_vals = {
-            "company_id": self.main_company.id,
-            "warehouse_id": self.warehouse.id,
-            "location_id": self.warehouse.lot_stock_id.id,
-            "expected_date": fields.Datetime.now(),
-            "stock_request_ids": [
-                Command.create(
-                    {
-                        "product_id": self.product.id,
-                        "product_uom_id": self.product.uom_id.id,
-                        "product_uom_qty": 5.0,
-                    },
-                ),
-                Command.create(
-                    {
-                        "product_id": self.product.id,
-                        "product_uom_id": self.product.uom_id.id,
-                        "product_uom_qty": 10.0,
-                    },
-                ),
-            ],
-        }
-        order = self.request_order.create(order_vals)
-        order.route_id = self.route.id
-        order._inverse_route_id()
-        for request in order.stock_request_ids:
-            self.assertEqual(
-                request.route_id.id,
-                self.route.id,
-                "Route ID should propagate to all stock requests.",
-            )
-
     def test_onchange_route_id_propagation(self):
         order_vals = {
             "company_id": self.main_company.id,
@@ -1641,3 +1512,69 @@ class TestStockRequestOrderChainedTransfers(common.TransactionCase):
         order = self.request_order.with_user(self.stock_request_user).create(vals)
         order.with_user(self.stock_request_manager).action_confirm()
         self.assertEqual(len(order.mapped("picking_ids")), 2)
+
+    def test_route_consistency(self):
+        vals = {
+            "company_id": self.main_company.id,
+            "warehouse_id": self.warehouse.id,
+            "location_id": self.warehouse.lot_stock_id.id,
+            "route_id": self.route.id,
+            "expected_date": fields.Datetime.now(),
+        }
+        order = self.request_order.with_user(self.stock_request_user).create(vals)
+        self.assertEqual(
+            order.route_id, self.route, "Order should have the initial route set"
+        )
+        self.product_test.route_ids = [Command.set(self.route.ids)]
+        line_vals = {
+            "product_id": self.product_test.id,
+            "product_uom_id": self.product_test.uom_id.id,
+            "product_uom_qty": 5.0,
+            "order_id": order.id,
+        }
+        line = self.env["stock.request"].new(line_vals)
+        line.onchange_product_id()
+        self.assertEqual(
+            line.route_id, self.route, "Line should auto-fill route from Order"
+        )
+        line_vals["route_id"] = line.route_id.id
+        line1 = self.stock_request.with_user(self.stock_request_user).create(line_vals)
+        self.assertEqual(line1.route_id, self.route)
+        self.assertEqual(
+            order.route_id,
+            self.route,
+            "Order route should be preserved after adding line",
+        )
+        line2 = self.stock_request.with_user(self.stock_request_user).create(
+            {
+                "order_id": order.id,
+                "product_id": self.product_test.id,
+                "product_uom_id": self.product_test.uom_id.id,
+                "product_uom_qty": 1.0,
+            }
+        )
+        self.assertEqual(
+            order.route_id,
+            self.route,
+            "Order route should be preserved when adding line",
+        )
+        # Test clearing route on line clears order route
+        line1.route_id = False
+        line1.onchange_route_id()
+        self.assertFalse(
+            order.route_id, "Order route should be cleared when line route is cleared"
+        )
+        # Test setting route on order propagates to lines
+        order.route_id = self.route
+        order._onchange_route_id()
+        self.assertEqual(
+            line1.route_id, self.route, "Line 1 should have route propagated"
+        )
+        self.assertEqual(
+            line2.route_id, self.route, "Line 2 should have route propagated"
+        )
+        # Test clearing route on order clears all lines
+        order.route_id = False
+        order._onchange_route_id()
+        self.assertFalse(line1.route_id, "Line 1 route should be cleared")
+        self.assertFalse(line2.route_id, "Line 2 route should be cleared")

--- a/stock_request/views/stock_request_order_views.xml
+++ b/stock_request/views/stock_request_order_views.xml
@@ -138,6 +138,7 @@
                             'default_procurement_group_id': procurement_group_id,
                             'default_company_id': company_id,
                             'default_state': state,
+                            'default_route_id': route_id,
                             }"
                                 readonly="state != 'draft'"
                             >


### PR DESCRIPTION
This PR improves `route_id` behavior to prevent unnecessary resets and enable intelligent auto-completion.

**Key improvements:**
- **Auto-completion**: When adding a line with a product compatible with the order's route, the route is automatically filled
- **Sync**: Changes to route on order propagate to lines.

**Benefits:**
- Reduces manual data entry
- Prevents frustrating route resets when building multi-line orders
- Maintains consistency between order and line routes