### PR TITLE
[18.0][FIX] stock_return_request: Fix lot quantity calculation and supplier return domain

### DIFF
--- a/stock_return_request/models/stock_move.py
+++ b/stock_return_request/models/stock_move.py
@@ -25,9 +25,10 @@ class StockMove(models.Model):
                 move.returned_move_ids.mapped("qty_returnable")
             )
 
-    def _get_lot_returnable_qty(self, lot_id, qty=0):
+    def _get_lot_returnable_qty(self, lot_id):
         """Looks for chained returned moves to compute how much quantity
         from the original can be returned for a given lot"""
+        qty = 0
         for move in self.filtered(lambda x: x.state not in ["draft", "cancel"]):
             mls = move.move_line_ids.filtered(lambda x: x.lot_id == lot_id)
             qty += sum(mls.mapped("quantity"))

--- a/stock_return_request/models/stock_return_request.py
+++ b/stock_return_request/models/stock_return_request.py
@@ -459,10 +459,14 @@ class StockReturnRequestLine(models.Model):
             domain += [
                 ("location_dest_id", "=", self.request_id.return_from_location.id)
             ]
-        # Return to supplier. Search for moves that came from that location
+        # Return to supplier. Search for moves that brought products to current location
         else:
             domain += [
-                ("location_id", "child_of", self.request_id.return_to_location.id)
+                (
+                    "location_dest_id",
+                    "child_of",
+                    self.request_id.return_from_location.id,
+                )
             ]
         return domain
 


### PR DESCRIPTION
As I understand it, these are only bug fixes — I'm not trying to change the feature behavior:

- `_get_lot_returnable_qty`: Remove the default parameter to prevent accumulation.
- **Supplier return domain**: Search by `location_dest_id` instead of `location_id`.

These changes fix the currently failing tests.