### PR TITLE
[18.0][IMP] stock_request: Remove allocation_ids from a view and improve stock.view_move_form layout

### DIFF
--- a/stock_request/views/stock_move_views.xml
+++ b/stock_request/views/stock_move_views.xml
@@ -1,27 +1,32 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <record id="view_stock_move_operations" model="ir.ui.view">
-        <field name="name">stock.move.operations.form</field>
-        <field name="model">stock.move</field>
-        <field name="inherit_id" ref="stock.view_stock_move_operations" />
-        <field name="arch" type="xml">
-            <field name="move_line_ids" position="after">
-                <newline />
-                <field name="allocation_ids" />
-            </field>
-        </field>
-    </record>
     <record id="view_move_form" model="ir.ui.view">
         <field name="name">stock.move.form</field>
         <field name="model">stock.move</field>
         <field name="inherit_id" ref="stock.view_move_form" />
         <field name="arch" type="xml">
-            <group name="linked_group" position="after">
-                <newline />
-                <group name="allocations" string="Stock Request Allocations">
-                    <field name="allocation_ids" />
-                </group>
-            </group>
+            <field name="move_dest_ids" position="after">
+                <field
+                    name="allocation_ids"
+                    string="Stock Request Allocations"
+                    readonly="1"
+                >
+                    <list>
+                        <field name="stock_request_id" />
+                        <field name="stock_move_id" />
+                        <field name="product_id" />
+                        <field name="requested_product_uom_qty" />
+                        <field
+                            name="product_uom_id"
+                            options="{'no_open': True, 'no_create': True}"
+                            groups="uom.group_uom"
+                        />
+                        <field name="requested_product_qty" />
+                        <field name="allocated_product_qty" />
+                        <field name="open_product_qty" />
+                    </list>
+                </field>
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Remove `allocation_ids` from a view where it does not apply and improve `stock.view_move_form` layout.

