### PR TITLE
[18.0][IMP] stock_request: add default route in stock requests from order

### DIFF
--- a/stock_request/views/stock_request_order_views.xml
+++ b/stock_request/views/stock_request_order_views.xml
@@ -138,6 +138,7 @@
                             'default_procurement_group_id': procurement_group_id,
                             'default_company_id': company_id,
                             'default_state': state,
+                            'default_route_id': route_id,
                             }"
                                 readonly="state != 'draft'"
                             >


### PR DESCRIPTION
This was something that was in older versions but was removed (I believe it was accidentally when migrating to v16). See v15 [code](https://github.com/OCA/stock-logistics-warehouse/blob/15.0/stock_request/views/stock_request_order_views.xml#L123) with this implementation.