### PR TITLE
[18.0][FIX] stock_request: sudo access errors

### DIFF
--- a/stock_request/models/procurement_group.py
+++ b/stock_request/models/procurement_group.py
@@ -15,8 +15,10 @@ class ProcurementGroup(models.Model):
             if "stock_request_id" in procurement.values and procurement.values.get(
                 "stock_request_id"
             ):
-                req = self.env["stock.request"].browse(
-                    procurement.values.get("stock_request_id")
+                req = (
+                    self.env["stock.request"]
+                    .sudo()
+                    .browse(procurement.values.get("stock_request_id"))
                 )
                 if req.order_id:
                     new_procs.append(procurement._replace(origin=req.order_id.name))

--- a/stock_request/models/stock_location.py
+++ b/stock_request/models/stock_location.py
@@ -12,7 +12,9 @@ class StockLocation(models.Model):
     def _check_company_stock_request(self):
         if any(
             rec.company_id
-            and self.env["stock.request"].search(
+            and self.env["stock.request"]
+            .sudo()
+            .search(
                 [("company_id", "!=", rec.company_id.id), ("location_id", "=", rec.id)],
                 limit=1,
             )
@@ -27,7 +29,9 @@ class StockLocation(models.Model):
             )
         if any(
             rec.company_id
-            and self.env["stock.request.order"].search(
+            and self.env["stock.request.order"]
+            .sudo()
+            .search(
                 [
                     ("company_id", "!=", rec.company_id.id),
                     ("warehouse_id", "=", rec.id),

--- a/stock_request/models/stock_route.py
+++ b/stock_request/models/stock_route.py
@@ -12,7 +12,9 @@ class StockRoute(models.Model):
     def _check_company_stock_request(self):
         if any(
             rec.company_id
-            and self.env["stock.request"].search(
+            and self.env["stock.request"]
+            .sudo()
+            .search(
                 [("company_id", "!=", rec.company_id.id), ("route_id", "=", rec.id)],
                 limit=1,
             )

--- a/stock_request/models/stock_warehouse.py
+++ b/stock_request/models/stock_warehouse.py
@@ -11,7 +11,9 @@ class StockWarehouse(models.Model):
     @api.constrains("company_id")
     def _check_company_stock_request(self):
         if any(
-            self.env["stock.request"].search(
+            self.env["stock.request"]
+            .sudo()
+            .search(
                 [
                     ("company_id", "!=", rec.company_id.id),
                     ("warehouse_id", "=", rec.id),
@@ -28,7 +30,9 @@ class StockWarehouse(models.Model):
                 )
             )
         if any(
-            self.env["stock.request.order"].search(
+            self.env["stock.request.order"]
+            .sudo()
+            .search(
                 [
                     ("company_id", "!=", rec.company_id.id),
                     ("warehouse_id", "=", rec.id),


### PR DESCRIPTION
Users without stock request permissions (like an Inventory admin creating a new warehouse) could hit Access Errors because the module tries to fetch records from a model they don't have access to. We added sudo() to these reads to fix.