### PR TITLE
[18.0][FIX] stock_request_tier_validation: Set _tier_validation_state_field_is_computed to execute validations correctly

### DIFF
--- a/stock_request_tier_validation/models/stock_request_order.py
+++ b/stock_request_tier_validation/models/stock_request_order.py
@@ -8,7 +8,7 @@ class StockRequestOrder(models.Model):
     _inherit = ["stock.request.order", "tier.validation"]
     _state_from = ["draft"]
     _state_to = ["open"]
-
+    _tier_validation_state_field_is_computed = True
     _tier_validation_manual_config = False
 
     @api.model

--- a/stock_request_tier_validation/views/stock_request_order_view.xml
+++ b/stock_request_tier_validation/views/stock_request_order_view.xml
@@ -23,4 +23,15 @@
             </xpath>
         </field>
     </record>
+    <record id="view_stock_request_order_form" model="ir.ui.view">
+        <field name="model">stock.request.order</field>
+        <field name="inherit_id" ref="stock_request.stock_request_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_confirm']" position="attributes">
+                <attribute
+                    name="invisible"
+                >validation_status in ['pending', 'rejected'] or state != 'draft'</attribute>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
The state field is computed, and when a tier validation is configured, it is not executed correctly. As a result, any user can confirm a request order without going through the validation flow.

This commit sets `_tier_validation_state_field_is_computed` to ensure that validations are evaluated correctly and forces users to request validation before confirming the request order.

[IMP] stock_request_tier_validation: Hide the Confirm button when validation is pending or rejected

@pedrobaeza @LoisRForgeFlow could you please review this?