### PR TITLE
[19.0][FIX] stock_request: avoid RecursionError on cyclic move_orig_ids

### DIFF
--- a/stock_request/__manifest__.py
+++ b/stock_request/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Stock Request",
     "summary": "Internal request for stock",
-    "version": "19.0.1.0.1",
+    "version": "19.0.1.0.2",
     "license": "LGPL-3",
     "website": "https://github.com/OCA/stock-logistics-request",
     "author": "ForgeFlow, Odoo Community Association (OCA)",

--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -126,10 +126,18 @@ class StockRequest(models.Model):
                 )
 
     def _get_all_origin_moves(self, move):
-        all_moves = move
-        if move.move_orig_ids:
-            for orig_move in move.move_orig_ids:
-                all_moves |= self._get_all_origin_moves(orig_move)
+        # Collect the move and all its transitive origin moves. The traversal
+        # is iterative and keeps track of the moves already visited because
+        # ``move_orig_ids`` can form a cyclic graph (e.g. returning both legs
+        # of a two-step inter-warehouse transfer that share a transit
+        # location links each leg's return to the other). A naive recursion
+        # over such a cycle raises RecursionError.
+        all_moves = self.env["stock.move"]
+        moves_to_visit = move
+        while moves_to_visit:
+            moves_to_visit -= all_moves
+            all_moves |= moves_to_visit
+            moves_to_visit = moves_to_visit.move_orig_ids
         return all_moves
 
     @api.depends("allocation_ids", "allocation_ids.stock_move_id")

--- a/stock_request/tests/test_stock_request.py
+++ b/stock_request/tests/test_stock_request.py
@@ -685,6 +685,53 @@ class TestStockRequestBase(TestStockRequest):
         self.assertEqual(order.state, "done")
         self.assertEqual(stock_request.state, "done")
 
+    def test_compute_move_ids_cyclic_origin_moves(self):
+        """A cycle in ``move_orig_ids`` must not raise RecursionError.
+
+        Returning both legs of a two-step inter-warehouse transfer that share
+        a transit location links each leg's return move back to the other,
+        so ``move_orig_ids`` becomes circular. Computing ``move_ids`` /
+        ``picking_ids`` used to recurse infinitely over that graph.
+        """
+        vals = {
+            "product_id": self.product.id,
+            "product_uom_id": self.product.uom_id.id,
+            "product_uom_qty": 1.0,
+            "company_id": self.main_company.id,
+            "warehouse_id": self.warehouse.id,
+            "location_id": self.warehouse.lot_stock_id.id,
+        }
+        stock_request = self.stock_request.with_user(self.stock_request_user).create(
+            vals
+        )
+        self.product.route_ids = [Command.set(self.route.ids)]
+        stock_request.with_user(self.stock_request_manager).action_confirm()
+
+        move_a = stock_request.allocation_ids.stock_move_id.sudo()
+        self.assertTrue(move_a, "The confirmed request should have a stock move")
+        move_b = (
+            self.env["stock.move"]
+            .sudo()
+            .create(
+                {
+                    "product_id": self.product.id,
+                    "product_uom_qty": 1.0,
+                    "product_uom": self.product.uom_id.id,
+                    "location_id": self.warehouse.lot_stock_id.id,
+                    "location_dest_id": self.warehouse.lot_stock_id.id,
+                    "company_id": self.main_company.id,
+                }
+            )
+        )
+        # Build the cycle: A -> B -> A.
+        move_a.move_orig_ids = [Command.link(move_b.id)]
+        move_b.move_orig_ids = [Command.link(move_a.id)]
+
+        request_sudo = stock_request.sudo()
+        request_sudo.invalidate_recordset(["move_ids", "picking_ids", "picking_count"])
+        # Must not raise RecursionError, and must collect both moves once.
+        self.assertEqual(request_sudo.move_ids, move_a | move_b)
+
     def test_create_request_02(self):
         """Use different UoM's"""
 


### PR DESCRIPTION
## Description

Opening the stock request order form crashes with `RecursionError: maximum recursion depth exceeded` (RPC_ERROR / OwlError on `onWillStart`) whenever the underlying `move_orig_ids` graph is circular. Stock and quantities stay correct — only the traceability compute breaks.

This happens when both legs of a two-step inter-warehouse transfer (which share a common transit location) are returned: each leg's return move ends up linked back to the other, forming a cycle in `move_orig_ids`.

`stock.request._get_all_origin_moves` walked `move_orig_ids` recursively **without tracking the moves already visited**, so on such a cycle it recurses infinitely. It is reached from `_compute_move_ids` → `_compute_picking_ids` (`stock_request`) → `_compute_picking_ids` (`stock_request_order`).

## Change

- Make `_get_all_origin_moves` iterative and cycle-safe: keep the already-visited moves in the accumulator and never revisit them. No `move_orig_ids` graph a user can build from the UI should raise `RecursionError`.

## How to test

1. Create a stock request that generates a two-step transfer between two warehouses (route through the shared transit location).
2. Validate the two pickings that are generated (outgoing from source, incoming to destination).
3. On each of those two pickings, press **Return** and validate the returns.
4. Re-open the stock request → before the fix the form fails to load; after, it opens normally.

An automated test (`test_compute_move_ids_cyclic_origin_moves`) reproduces the cycle and asserts the compute no longer raises.

## Notes

- Version bumped to `19.0.1.0.2`.
- I could not regenerate `README.rst` / `index.html` locally (no `pandoc` in my environment); the change adds no readme fragment, so there is nothing to regenerate content-wise — happy to let the OCA readme bot run.
